### PR TITLE
fix: fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Release
         run: |
           git config user.name 'github-actions'


### PR DESCRIPTION
## このPullRequestが解決する内容
`git clone --depth 1` だと remote tag を取得できないことを失念していたため、すべての履歴を取得するように修正します。
自明のためセルフマージします。